### PR TITLE
Suggested edits to email templates for PyCon 2020

### DIFF
--- a/templates/email/accept.txt
+++ b/templates/email/accept.txt
@@ -22,11 +22,15 @@ If you have any other questions, comments, or feedback, please feel free to cont
 
 On behalf of the PyCon staff, the Program team would like to thank you for your submission. We're looking forward to seeing you at the conference; PyCon 2020 promises to be the best PyCon yet, and that's because of our amazing speakers. We're thrilled that you're one of them.
 
-See you in Cleveland!
+See you in Pittsburgh!
 
-Jason Myers
-Jackie Kazil
+
+
+Melinda Shore
 Lorena Mesa
+Philippe Gagnon
+Brian Costlow
+Maricela Sanchez Miranda
 Program Chairs, PyCon 2020
 pycon-program-committee@python.org
 

--- a/templates/email/decline.txt
+++ b/templates/email/decline.txt
@@ -48,13 +48,15 @@ On behalf of the PyCon staff, I want to thank you again for your
 submission. You made our job of picking talks very hard, and the
 conference will be better for it.
 
-I hope to see you in Cleveland!
+I hope to see you in Pittsburgh!
 
 
 
-Jason Myers
-Jackie Kazil
+Melinda Shore
 Lorena Mesa
+Philippe Gagnon
+Brian Costlow
+Maricela Sanchez Miranda
 Program Chairs, PyCon 2020
 pycon-program-committee@python.org
 

--- a/templates/email/feedback_notice.txt
+++ b/templates/email/feedback_notice.txt
@@ -12,6 +12,9 @@ To response to this message directly, please go here:
 
 {{url}}
 
+Please do not identify yourself in your reply, as
+talk reviews are to remain anonymous at this time.
+
 To edit your talk, please go here:
 
 {{edit_url}}


### PR DESCRIPTION
A couple of suggested edits to email templates:

- Update name of committee members;
- Replace references to Cleveland with Pittsburgh;
- Add a notice requesting that submitters do not identify themselves when replying to review feedback.